### PR TITLE
[IDP-1904] Fix client generation

### DIFF
--- a/packages/create-schemas/src/plugins/openapi-typescript-plugin.ts
+++ b/packages/create-schemas/src/plugins/openapi-typescript-plugin.ts
@@ -1,7 +1,7 @@
 import openapiTS, { astToString } from "openapi-typescript";
 import type { Plugin } from "./plugin.ts";
 
-export const openapiTypeScriptId = Symbol();
+export const openapiTypeScriptId = "internal:openapi-typescript-plugin";
 
 export const openapiTypeScriptFilename = "types.ts";
 

--- a/packages/create-schemas/tests/e2e.test.ts
+++ b/packages/create-schemas/tests/e2e.test.ts
@@ -7,6 +7,7 @@ import { assert, describe, test } from "vitest";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { openapiTypeScriptFilename } from "../src/plugins/openapi-typescript-plugin.ts";
+import { writeFile } from "node:fs/promises";
 
 const timeout = 30 * 1000; // 30 seconds
 
@@ -93,6 +94,33 @@ describe.concurrent("e2e", () => {
             const typesFile = result.find(file => file.filename === openapiTypeScriptFilename);
             assert(typesFile);
             expect(typesFile.code).toMatchSnapshot();
+        },
+        timeout
+    );
+
+    test(
+        "petstore.json / generate openapi-fetch client",
+        async ({ expect, onTestFinished }) => {
+            const tempFolder = await createTemporaryFolder({ onTestFinished: onTestFinished });
+
+            const configFile = `
+            import { openapiFetchPlugin } from "../../../src/plugins";
+            
+            export default { plugins: [openapiFetchPlugin()] };
+            `;
+
+            await writeFile(join(tempFolder, "create-schemas.config.ts"), configFile);
+
+            const result = await runCompiledBin({
+                source: join(dataFolder, "petstore.json"),
+                outdir: join(tempFolder, "dist"),
+                cwd: tempFolder
+            });
+
+            console.log(result);
+
+            const clientFile = result.find(file => file.filename === "client.ts");
+            expect(clientFile).toBeDefined();
         },
         timeout
     );

--- a/packages/create-schemas/tests/generate.test.ts
+++ b/packages/create-schemas/tests/generate.test.ts
@@ -4,6 +4,7 @@ import { resolveConfig } from "../src/config.ts";
 import { join } from "path";
 import { dataFolder } from "./fixtures.ts";
 import { openapiTypeScriptFilename } from "../src/plugins/openapi-typescript-plugin.ts";
+import { openapiFetchPlugin } from "../src/plugins/openapi-fetch-plugin.ts";
 
 describe.concurrent("generate", () => {
     test("sanitize names", async ({ expect }) => {
@@ -40,5 +41,15 @@ describe.concurrent("generate", () => {
         };
 
         expect(fn).rejects.toThrow();
+    });
+
+    test("generate client", async ({ expect }) => {
+        const { files } = await generate(await resolveConfig({
+            input: join(dataFolder, "todo.json"),
+            plugins: [openapiFetchPlugin()]
+        }));
+
+        const clientFile = files.find(file => file.filename === "client.ts");
+        expect(clientFile).toBeDefined();
     });
 });


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes

Oops! The `openapiTypeScriptId` variable being a `Symbol` didn't work as expected when loading the user configuration with c12, because [jiti](https://www.npmjs.com/package/jiti) (the tool c12 uses to load and read our TypeScript configuration) created another instance of the Symbol, making all comparisons fail.

Turned the `id` from a `Symbol` into a `string` so that comparisons now work properly.
