### PR TITLE
[IDP-1845] Fix deployment

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,6 +1,7 @@
 name: Publish Docs
 
 on:
+  workflow_dispatch:
   push:
     branches:
     - main
@@ -26,9 +27,8 @@ jobs:
           license: ${{ secrets.RETYPE_API_KEY }}
 
       - name: Upload Retype artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-pages-artifact@v2
         with:
-          name: github-pages
           path: ${{ steps.retype.outputs.retype-output-path }}
       
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes

My Github Actions-fu is still weak. Turns out that Github Pages only accept artifacts bundle in a specific way, which require the usage of the `actions/upload-pages-artifact@v2` step.
