### PR TITLE
[IDP-1845] Fix docs deploy

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -12,14 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-
-    environment:
-      name: github-pages
-      url: ${{steps.deployment.outputs.page_url}}
-
+      contents: write  # to update the retype branch
+    
     steps:
       - uses: actions/checkout@v4
 
@@ -30,11 +24,6 @@ jobs:
           config: docs/retype.yaml
           license: ${{ secrets.RETYPE_API_KEY }}
 
-      - name: Upload Retype artifact
-        uses: actions/upload-pages-artifact@v2
+      - uses: retypeapp/action-github-pages@latest
         with:
-          path: ${{ steps.retype.outputs.retype-output-path }}
-      
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          update-branch: true


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
<!-- What was changed in this pull request? -->

I don't know why, but the [deploy-pages](https://github.com/actions/deploy-pages) action keeps failing despite matching the examples from the documentation. I suppose that's the price one has to pay to be cutting edge.

Replaced the "Pipeline Deployment" with the "Classic Deployment" method of Github Pages.

Now, instead of publishing a pipeline artifact, Github Pages will display the content of the `/retype` branch, which is generated by the pipeline.


