### PR TITLE
[IDP-1927] Fix typo in documentation

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -29,7 +29,7 @@ import { defineConfig } from "@workleap/create-schemas";
 
 export default defineConfig({
   input: "https://petstore3.swagger.io/api/v3/openapi.json", // replace with your own OpenAPI schema
-  output: "src/codegen/schema.ts",
+  outdir: "src/codegen",
 });
 ```
 
@@ -49,7 +49,7 @@ yarn create-schemas
 ```
 +++
 
-The `src/codegen/schema.ts` file should be created.
+The `src/codegen/types.ts` file should be created.
 
 ## Watch mode
 


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
Fix the example in Getting Started page.

`outfile` was changed to be `outdir` in a previous pull-request, but the documentation had not been updated.

## Breaking changes
<!-- What breaking changes were added (if any) and how are they addressed? -->
N/A

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->
N/A

- [x] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
