### PR TITLE
[IDP-2744] Fix concurrency option to support renovate fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,9 @@ on:
 env:
   CI: true
 
+# Prevent duplicate runs if Renovate falls back to creating a PR
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "github>gsoft-inc/renovate-config",
+        "github>gsoft-inc/renovate-config:all-automerge.json"
+    ]
+}


### PR DESCRIPTION
## Description of changes

- Setup concurrency option to prevent duplicate run when Renovate falls back to creating a PR
- Pin ubuntu since latest doesn't work and out-of-scope

